### PR TITLE
Add lodash as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/warbrett/node-cronofy#readme",
   "dependencies": {
+    "lodash": "^3.10.1",
     "origami": "^0.3.0",
     "rest": "^1.3.1",
     "when": "^3.7.4"


### PR DESCRIPTION
Since it is used everywhere and only works as a side effect of npm 3 this should be added as a dependency. I used the version that gets installed by the submodules (semistandard and babel) but I can up it to the latest version if you want.