### PR TITLE
proper string literal usage for method paths

### DIFF
--- a/src/methods/create-event.js
+++ b/src/methods/create-event.js
@@ -9,7 +9,7 @@ import rest from '../lib/rest-client';
 function createEvent (options, callback) {
   const settings = {
     method: 'POST',
-    path: 'https://api.cronofy.com/v1/calendars/' + options.calendar_id + '/events',
+    path: `https://api.cronofy.com/v1/calendars/${options.calendar_id}/events`,
     headers: {
       Authorization: 'Bearer ' + options.access_token
     },

--- a/src/methods/delete-notification-channel.js
+++ b/src/methods/delete-notification-channel.js
@@ -8,7 +8,7 @@ import rest from '../lib/rest-client';
 function deleteNotificationChannel (options, callback) {
   const settings = {
     method: 'DELETE',
-    path: 'https://api.cronofy.com/v1/channels/${options.channel_id}',
+    path: `https://api.cronofy.com/v1/channels/${options.channel_id}`,
     headers: {
       Authorization: 'Bearer ' + options.access_token
     }


### PR DESCRIPTION
This fixes a bug for `deleteNotificationChannel` and makes sure all paths are string literals